### PR TITLE
Made it eject all connected disks

### DIFF
--- a/Version 1.2.1/eject
+++ b/Version 1.2.1/eject
@@ -1,9 +1,7 @@
-shell.run("delete","install")
-shell.run("delete","eject")
-disk.eject("top")
-disk.eject("bottom")
-disk.eject("left")
-disk.eject("right")
-disk.eject("front")
-disk.eject("back")
+fs.delete("eject")
+fs.delete("install")
+local disks = {peripheral.find("drive")}
+for a = 1, #disks do
+  disk.eject(disks[a])
+end
 os.reboot()


### PR DESCRIPTION
The previous code only ejected disks connected directly to the machine, but now it ejects ALL connected disk drives.
I also replaced the shell.run("delete") with fs.delete().